### PR TITLE
Fix typo in env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.1.1 (1/23/2017)
+
+* Fix typo in ENV variable - [@ashkan18](https://github.com/ashkan18).
+
 ### 0.1.0 (12/29/2016)
 
-* Initial public release - [@ashkan18](https://github.com/askan18).
+* Initial public release - [@ashkan18](https://github.com/ashkan18).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    artsy-eventservice (0.1.0)
+    artsy-eventservice (0.1.1)
       bunny (~> 2.6.2)
 
 GEM

--- a/lib/artsy-eventservice/artsy/event_service.rb
+++ b/lib/artsy-eventservice/artsy/event_service.rb
@@ -7,7 +7,7 @@ module Artsy
         ENV['RABBITMQ_URL'],
         tls: true,
         tls_cert: Base64.decode64(ENV['RABBITMQ_CLIENT_CERT'] || ''),
-        tls_key: Base64.decode64(ENV['RABBTIMQ_CLIENT_KEY'] || ''),
+        tls_key: Base64.decode64(ENV['RABBITMQ_CLIENT_KEY'] || ''),
         tls_ca_certificates: [Base64.decode64(ENV['RABBITMQ_CA_CERT'] || '')],
         verify_peer: true
       )

--- a/lib/artsy-eventservice/version.rb
+++ b/lib/artsy-eventservice/version.rb
@@ -1,6 +1,6 @@
 module Artsy
   module EventService
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
   end
 end
 


### PR DESCRIPTION
Fixed typo in `RABBITMQ_CLIENT_KEY` variable 😞 