### PR TITLE
Fix potential thread-safety issue

### DIFF
--- a/lib/artsy-eventservice/artsy/event_service.rb
+++ b/lib/artsy-eventservice/artsy/event_service.rb
@@ -2,8 +2,8 @@ require 'bunny'
 
 module Artsy
   module EventService
-    def self.conn
-      @conn ||= Bunny.new(
+    def self.create_conn
+      Bunny.new(
         ENV['RABBITMQ_URL'],
         tls: true,
         tls_cert: Base64.decode64(ENV['RABBITMQ_CLIENT_CERT'] || ''),
@@ -16,6 +16,7 @@ module Artsy
     def self.post_event(topic:, event:)
       return unless ENV['EVENT_STREAM_ENABLED']
       raise 'Event missing topic or verb.' if event.verb.to_s.empty? || topic.to_s.empty?
+      conn = create_conn
       conn.start
       channel = conn.create_channel
       exchange = channel.topic(topic, durable: true)

--- a/lib/artsy-eventservice/version.rb
+++ b/lib/artsy-eventservice/version.rb
@@ -1,6 +1,6 @@
 module Artsy
   module EventService
-    VERSION = '0.1.1'
+    VERSION = '0.1.2'
   end
 end
 

--- a/spec/artsy-eventstream/artsy/event_service_spec.rb
+++ b/spec/artsy-eventstream/artsy/event_service_spec.rb
@@ -38,7 +38,7 @@ describe Artsy::EventService do
       end
       it 'calls publish on the exchange with proper data' do
         conn = double
-        expect(Artsy::EventService).to receive(:conn).at_least(3).times.and_return(conn)
+        expect(Artsy::EventService).to receive(:create_conn).once.and_return(conn)
         expect(conn).to receive(:start).once
         expect(conn).to receive(:close).once
         channel = double


### PR DESCRIPTION
# Issue
We create a `conn` and assign it to class instance variable and then we call `.start` and `.create_channel` on it but since each of them instead of accessing instance variable, call `conn` there is a potential issue of creating a new connection instead of using existing one which can potentially cause publishing issues.