### PR TITLE
add RABBITMQ_NO_TLS / RABBITMQ_NO_VERIFY_PEER env var switches

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    artsy-eventservice (0.1.2)
+    artsy-eventservice (0.1.3)
       bunny (~> 2.6.2)
 
 GEM

--- a/lib/artsy-eventservice/artsy/event_service.rb
+++ b/lib/artsy-eventservice/artsy/event_service.rb
@@ -7,9 +7,9 @@ module Artsy
       params = { tls: tls }
       if tls
         params.merge!({
-          tls_cert: Base64.decode64(ENV['RABBITMQ_CLIENT_CERT'] || ''),
-          tls_key: Base64.decode64(ENV['RABBITMQ_CLIENT_KEY'] || ''),
-          tls_ca_certificates: [Base64.decode64(ENV['RABBITMQ_CA_CERT'] || '')],
+          tls_cert: Base64.decode64(ENV['RABBITMQ_CLIENT_CERT']),
+          tls_key: Base64.decode64(ENV['RABBITMQ_CLIENT_KEY']),
+          tls_ca_certificates: [Base64.decode64(ENV['RABBITMQ_CA_CERT'])],
           verify_peer: ENV['RABBITMQ_NO_VERIFY_PEER'] == 'true' ? false : true
         })
       end

--- a/lib/artsy-eventservice/version.rb
+++ b/lib/artsy-eventservice/version.rb
@@ -1,6 +1,6 @@
 module Artsy
   module EventService
-    VERSION = '0.1.2'
+    VERSION = '0.1.3'
   end
 end
 


### PR DESCRIPTION
We can set the env vars RABBITMQ_NO_VERIFY_PEER=true to disable verify_peer and RABBITMQ_NO_TLS=true to disable tls altogether (for internal VPC traffic)