### PR TITLE
Switch to new configuration approach, add readme

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    artsy-eventservice (0.1.5)
+    artsy-eventservice (1.0)
       bunny (~> 2.6.2)
 
 GEM
@@ -76,4 +76,4 @@ RUBY VERSION
    ruby 2.3.0p0
 
 BUNDLED WITH
-   1.13.6
+   1.14.6

--- a/README.md
+++ b/README.md
@@ -4,8 +4,26 @@ Ruby Gem for producing events in Artsy's event stream.
 ## Installation
 Add following line to your Gemfile
 
-```
+```ruby
 gem 'artsy-eventservice'
+```
+
+## Configuration
+
+Add `artsy_eventservice.rb under config/initializers. `Artsy::EventService` uses [Bunny](http://rubybunny.info/) to connect to RabbitMQ. Here is a sample of configuration:
+
+```ruby
+# config/initializers/artsy_eventservice.rb
+Artsy::EventService.configure do |config|
+  config.app_name = 'my-app'  # Used for RabbitMQ queue name
+  config.event_stream_enabled = true  # Boolean used to enable/disable posting events
+  config.rabbitmq_url = 'amqp(s)://<user>:<pass>@<host>:<port>/<vhost>'  # required
+  config.tls = true  # required, Currently only supports TLS enabled
+  config.tls_ca_certificate = <base64 strict decoded>
+  config.tls_cert = <base64 strict decoded>
+  config.tls_key = <base64 strict decoded>
+  config.verify_peer = true  # Boolean used to decide in case we are using tls, we should verify peer or not
+end
 ```
 
 ## Usage
@@ -30,15 +48,8 @@ module Events
 end
 ```
 
-`Artsy::EventService` uses [Bunny](http://rubybunny.info/) to securly connect to RabbitMQ over ssl, make sure following environment variables are set in your project:
-```
-RABBITMQ_URL="something like amqps://<user>:<pass>@rabbitmq.artsy.net:<port>/<vhost>"
-RABBITMQ_CLIENT_CERT=base64 strict decoded
-RABBTIMQ_CLIENT_KEY=base64 strict decoded
-RABBITMQ_CA_CERT=base64 strict decoded
-```
 
-### Enabaling Posting Events
+### Enabling Posting Events
 We have a feature flag setup for enabling/disabling EventService. Setting `EVENT_STREAM_ENABLED` env variable will enable posting events. Not having this env means event service is disabled and no events will actually be sent.
 
 
@@ -48,6 +59,9 @@ Call `post_event` with proper `topic` and `event`:
 Artsy::EventService.post_event(topic: 'testing', event: event_model)
 ```
 
+
+### Update to Version 1.0
+In previous versions this gem was using Environment variables for configuration. On version 1.0, configuration step is now mandatory and it will no longer read environment variables directly. Make sure to go to configuration step.
 
 # Contributing
 

--- a/lib/artsy-eventservice/artsy/event_service.rb
+++ b/lib/artsy-eventservice/artsy/event_service.rb
@@ -2,24 +2,6 @@
 # frozen_string_literal: true
 module Artsy
   module EventService
-    CONFIG = OpenStruct.new(initial_config)
-
-    ## Configure the Artsy-EventService in an initializer. Ex:
-    # initializers/artsy_eventservice.rb
-    #
-    # Artsy::EventService.configure do |es|
-    #   es.config.cool = true
-    #   es.post_event topic: 'artsy-eventservice', event: {'configured' => true}
-    # end
-    def self.configure
-      yield(self) if block_given?
-    end
-
-    # Get configuration object
-    def self.config
-      CONFIG
-    end
-
     def self.post_event(topic:, event:)
       return unless event_stream_enabled?
       Publisher.publish(topic: topic, event: event)
@@ -29,9 +11,8 @@ module Artsy
       raise 'Not implemented- try Sneakers'
     end
 
-
     def self.event_stream_enabled?
-      config.event_stream_enabled
+      Artsy::EventService.config.event_stream_enabled
     end
   end
 end

--- a/lib/artsy-eventservice/config.rb
+++ b/lib/artsy-eventservice/config.rb
@@ -1,18 +1,42 @@
 # frozen_string_literal: true
-require 'ostruct'
+
 module Artsy
   module EventService
-    def self.initial_config
-      {
-        app_name: defined?(Rails) ? Rails.application.class.to_s.split('::').first : 'artsy',
-        event_stream_enabled:         ENV['EVENT_STREAM_ENABLED'] == 'true',
-        rabbitmq_url:                 ENV['RABBITMQ_URL'] || nil,
-        tls:                          !(ENV['RABBITMQ_NO_TLS'] == 'true'),
-        tls_ca_certificate:           ENV['RABBITMQ_CA_CERT']     ? Base64.decode64(ENV['RABBITMQ_CA_CERT'])     : nil,
-        tls_cert:                     ENV['RABBITMQ_CLIENT_CERT'] ? Base64.decode64(ENV['RABBITMQ_CLIENT_CERT']) : nil,
-        tls_key:                      ENV['RABBITMQ_CLIENT_KEY']  ? Base64.decode64(ENV['RABBITMQ_CLIENT_KEY'])  : nil,
-        verify_peer:                  !(ENV['RABBITMQ_NO_VERIFY_PEER'] == 'true')
-      }
+    module Config
+      extend self
+
+      attr_accessor :app_name
+      attr_accessor :event_stream_enabled
+      attr_accessor :rabbitmq_url
+      attr_accessor :tls
+      attr_accessor :tls_ca_certificate
+      attr_accessor :tls_cert
+      attr_accessor :tls_key
+      attr_accessor :verify_peer
+
+      def reset
+        self.app_name = nil
+        self.event_stream_enabled = false
+        self.rabbitmq_url = nil
+        self.tls = nil
+        self.tls_ca_certificate = nil
+        self.tls_cert = nil
+        self.tls_key = nil
+        self.verify_peer = nil
+      end
+
+      reset
+    end
+
+    class << self
+      def configure
+        yield(Config) if block_given?
+        Config
+      end
+
+      def config
+        Config
+      end
     end
   end
 end

--- a/lib/artsy-eventservice/version.rb
+++ b/lib/artsy-eventservice/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Artsy
   module EventService
-    VERSION = '0.1.5'
+    VERSION = '1.0'
   end
 end

--- a/spec/artsy-eventstream/artsy/event_service_spec.rb
+++ b/spec/artsy-eventstream/artsy/event_service_spec.rb
@@ -4,27 +4,9 @@ require 'spec_helper'
 describe Artsy::EventService do
   let(:event) { double('event', topic: 'foo', verb: 'bar') }
 
-  context 'configuration' do
-    describe '.config' do
-      it 'accesses the module configuration' do
-        expect(Artsy::EventService.config.app_name).to eq 'artsy'
-      end
-    end
-    describe '.configure' do
-      before { stub_const 'Artsy::EventService::CONFIG', Artsy::EventService::CONFIG.dup }
-      it 'allows access to the module, including mutable configuration' do
-        default = Artsy::EventService.config.event_stream_enabled
-        expected = !default
-        Artsy::EventService.configure { |es| es.config.event_stream_enabled = expected}
-        expect(Artsy::EventService.config.event_stream_enabled).to be expected
-      end
-    end
-
-  end
-
   context 'event stream disabled' do
     before do
-      stub_const('Artsy::EventService::CONFIG', double(event_stream_enabled: false))
+      allow(Artsy::EventService).to receive(:config).and_return(double(event_stream_enabled: false))
     end
     describe '.post_event' do
       it 'does not connect to rabbit' do
@@ -36,7 +18,7 @@ describe Artsy::EventService do
 
   context 'event stream enabled' do
     before do
-      stub_const('Artsy::EventService::CONFIG', double(event_stream_enabled: true))
+      allow(Artsy::EventService).to receive(:config).and_return(double(event_stream_enabled: true))
     end
     describe '.post_event' do
       it 'does connect to rabbit' do

--- a/spec/artsy-eventstream/artsy/publisher_spec.rb
+++ b/spec/artsy-eventstream/artsy/publisher_spec.rb
@@ -6,8 +6,11 @@ describe Artsy::EventService::Publisher do
   let(:event) { double('event', topic: 'foo') }
 
   before do
-    Artsy::EventService.instance_variable_set('@configuration', nil)
-    ENV['EVENT_STREAM_ENABLED'] = 'true'
+    Artsy::EventService.configure do |config|
+      config.app_name = 'artsy'
+      config.event_stream_enabled = true
+      config.tls = true
+    end
     allow(event).to receive_messages(
       verb: 'testing',
       json: JSON.generate(hello: true)

--- a/spec/artsy-eventstream/config_spec.rb
+++ b/spec/artsy-eventstream/config_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require 'spec_helper'
+describe Artsy::EventService::Config do
+  describe '.configure' do
+    %w(app_name event_stream_enabled rabbitmq_url tls tls_ca_certificate tls_cert tls_key verify_peer).each do |option|
+      it "allows setting and getting #{option}" do
+        Artsy::EventService.configure { |config| config.send("#{option}=", false) }
+        expect(Artsy::EventService.config.send(option.to_sym)).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Changes
- Followed configuration approach we used for `artsy-auth`
- We no longer read environment variables directly and everything is set during initialization 
- Updated readme to reflect latest changes.