### PR TITLE
Support non-tls

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    artsy-eventservice (1.0)
+    artsy-eventservice (1.0.1)
       bunny (~> 2.6.2)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Artsy::EventService.configure do |config|
   config.app_name = 'my-app'  # Used for RabbitMQ queue name
   config.event_stream_enabled = true  # Boolean used to enable/disable posting events
   config.rabbitmq_url = 'amqp(s)://<user>:<pass>@<host>:<port>/<vhost>'  # required
-  config.tls = true  # required, Currently only supports TLS enabled
+  config.tls = true  # following configs are only used if tls is true
   config.tls_ca_certificate = <string content>
   config.tls_cert = <string content>
   config.tls_key = <string content>

--- a/lib/artsy-eventservice/artsy/event_service/rabbitmq_connection.rb
+++ b/lib/artsy-eventservice/artsy/event_service/rabbitmq_connection.rb
@@ -36,7 +36,7 @@ module Artsy
       end
 
       def no_tls_params
-        raise 'not implemented- TLS only'
+        {}
       end
 
       def config

--- a/lib/artsy-eventservice/version.rb
+++ b/lib/artsy-eventservice/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Artsy
   module EventService
-    VERSION = '1.0'
+    VERSION = '1.0.1'
   end
 end


### PR DESCRIPTION
Update to support `non-tls` connections, we'd basically not pass any extra params.