### PR TITLE
Support passing routing key

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    artsy-eventservice (1.0.1)
+    artsy-eventservice (1.0.2)
       bunny (~> 2.6.2)
 
 GEM

--- a/lib/artsy-eventservice/artsy/event_service.rb
+++ b/lib/artsy-eventservice/artsy/event_service.rb
@@ -2,9 +2,9 @@
 # frozen_string_literal: true
 module Artsy
   module EventService
-    def self.post_event(topic:, event:)
+    def self.post_event(topic:, event:, routing_key: nil)
       return unless event_stream_enabled?
-      Publisher.publish(topic: topic, event: event)
+      Publisher.publish(topic: topic, event: event, routing_key: routing_key)
     end
 
     def self.consume(**args)

--- a/lib/artsy-eventservice/artsy/event_service/publisher.rb
+++ b/lib/artsy-eventservice/artsy/event_service/publisher.rb
@@ -4,18 +4,18 @@ module Artsy
     class Publisher
       include RabbitMQConnection
 
-      def self.publish(topic:, event:)
-        new.post_event(topic: topic, event: event)
+      def self.publish(topic:, event:, routing_key: nil)
+        new.post_event(topic: topic, event: event, routing_key: routing_key)
       end
 
-      def post_event(topic:, event:)
+      def post_event(topic:, event:, routing_key: nil)
         raise 'Event missing topic or verb.' if event.verb.to_s.empty? || topic.to_s.empty?
         connect_to_rabbit do |conn|
           channel = conn.create_channel
           exchange = channel.topic(topic, durable: true)
           exchange.publish(
             event.json,
-            routing_key: event.verb,
+            routing_key: routing_key || event.verb,
             persistent: true,
             content_type: 'application/json',
             app_id: config.app_name

--- a/lib/artsy-eventservice/version.rb
+++ b/lib/artsy-eventservice/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Artsy
   module EventService
-    VERSION = '1.0.1'
+    VERSION = '1.0.2'
   end
 end

--- a/spec/artsy-eventstream/artsy/event_service_spec.rb
+++ b/spec/artsy-eventstream/artsy/event_service_spec.rb
@@ -21,10 +21,15 @@ describe Artsy::EventService do
       allow(Artsy::EventService).to receive(:config).and_return(double(event_stream_enabled: true))
     end
     describe '.post_event' do
-      it 'does connect to rabbit' do
-        expect(Artsy::EventService::Publisher).to receive(:publish)
+      it 'calls publish with proper params' do
+        expect(Artsy::EventService::Publisher).to receive(:publish).with(topic: 'test', event: event, routing_key: nil)
 
         Artsy::EventService.post_event(topic: 'test', event: event)
+      end
+      it 'calls publish with proper params with routing key' do
+        expect(Artsy::EventService::Publisher).to receive(:publish).with(topic: 'test', event: event, routing_key: 'good.route')
+
+        Artsy::EventService.post_event(topic: 'test', event: event, routing_key: 'good.route')
       end
     end
   end


### PR DESCRIPTION
# Problem
We are currently only supporting using `verb` as the routing key, we need to support custom `routing_key`s

# Solution
Update current methods to accept optional `routing_key` and if it was not passed in use `event`'s `verb` 