### PR TITLE
Add default routing_key

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    artsy-eventservice (1.0.2)
+    artsy-eventservice (1.0.3)
       bunny (~> 2.6.2)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Few examples:
 ### Update to Version 1.0
 In previous versions this gem was using Environment variables for configuration. On version 1.0, configuration step is now mandatory and it will no longer read environment variables directly. Make sure to go to configuration step.
 
+### Update to Version 1.0.3
+Since this version we've updated `routing_key` to default to `<event object class name>.<event.verb>`. This means if your consumers were listening on `verb` routing key, now they need to update to include object's class name.
+You can always override this feature by passing in `routing_key` to `post_event`.
+
 # Contributing
 
 * Fork the project.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ Call `post_event` with proper `topic` and `event`:
 Artsy::EventService.post_event(topic: 'testing', event: event_model)
 ```
 
+# How to pick topic and routing key?
+Think of topic as high level business area. From consumer perspective there will be one connection per topic, consumer can decide to filter events they want to receive in that topic based on `routing_key` they listening on. For `topic` use plural names.
+
+We recommend to use following `routing_key` strategy:
+`<model_name>.<verb>`.
+
+Few examples:
+- Topic: `conversations`, routing key: `message.sent`
+- Topic: `conversations`, routing key: `conversation.created`
+- Topic: `conversations`, routing key: `conversation.dismissed`
+- Topic: `invoices`, routing key: `invoice.paid`
+- Topic: `invoices`, routing key: `merchant_account.created`
+
+`BaseEvent` provides `routing_key` method by default which follows the same pattern mention above, you can override `routing_key` when calling `post_event`.
 
 ### Update to Version 1.0
 In previous versions this gem was using Environment variables for configuration. On version 1.0, configuration step is now mandatory and it will no longer read environment variables directly. Make sure to go to configuration step.

--- a/lib/artsy-eventservice/artsy/event_service.rb
+++ b/lib/artsy-eventservice/artsy/event_service.rb
@@ -4,7 +4,7 @@ module Artsy
   module EventService
     def self.post_event(topic:, event:, routing_key: nil)
       return unless event_stream_enabled?
-      Publisher.publish(topic: topic, event: event, routing_key: routing_key)
+      Publisher.publish(topic: topic, event: event, routing_key: routing_key || event.routing_key)
     end
 
     def self.consume(**args)

--- a/lib/artsy-eventservice/presenters/events/base_event.rb
+++ b/lib/artsy-eventservice/presenters/events/base_event.rb
@@ -36,5 +36,9 @@ module Events
                     object: object,
                     properties: properties)
     end
+
+    def routing_key
+      "#{@object.class.to_s.downcase.gsub('::', '-')}.#{@verb}"
+    end
   end
 end

--- a/lib/artsy-eventservice/version.rb
+++ b/lib/artsy-eventservice/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Artsy
   module EventService
-    VERSION = '1.0.2'
+    VERSION = '1.0.3'
   end
 end

--- a/spec/artsy-eventstream/artsy/event_service_spec.rb
+++ b/spec/artsy-eventstream/artsy/event_service_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe Artsy::EventService do
-  let(:event) { double('event', topic: 'foo', verb: 'bar') }
+  let(:event) { double('event', topic: 'foo', verb: 'bar', routing_key: 'test.passed') }
 
   context 'event stream disabled' do
     before do
@@ -22,7 +22,7 @@ describe Artsy::EventService do
     end
     describe '.post_event' do
       it 'calls publish with proper params' do
-        expect(Artsy::EventService::Publisher).to receive(:publish).with(topic: 'test', event: event, routing_key: nil)
+        expect(Artsy::EventService::Publisher).to receive(:publish).with(topic: 'test', event: event, routing_key: 'test.passed')
 
         Artsy::EventService.post_event(topic: 'test', event: event)
       end

--- a/spec/artsy-eventstream/presenters/events/base_event_spec.rb
+++ b/spec/artsy-eventstream/presenters/events/base_event_spec.rb
@@ -32,4 +32,9 @@ describe Events::BaseEvent do
       )
     end
   end
+  describe '#routing_key' do
+    it 'returns proper routing key' do
+      expect(event.routing_key).to eq 'rspec-mocks-double.test'
+    end
+  end
 end


### PR DESCRIPTION
# Problem
Currently we are defaulting `routing_key` to `verb` of `event` passed into `post_event` and we give option to override it by passing it in.
We need something more informative than just the verb of the event for `routing_key` so consumers can filter events based on more meaningful/useful `routing_key`.

# Solution
We added `routing_key` method to `BaseEvent` so all events inheriting `BaseEvent` would benefit from this. In `post_event` we now default to event's `routing_key` if nothing was passed in.

