### PR TITLE
confirm when publishing messages

### DIFF
--- a/lib/artsy-eventservice/artsy/event_service/publisher.rb
+++ b/lib/artsy-eventservice/artsy/event_service/publisher.rb
@@ -12,6 +12,7 @@ module Artsy
         raise 'Event missing topic or verb.' if event.verb.to_s.empty? || topic.to_s.empty?
         connect_to_rabbit do |conn|
           channel = conn.create_channel
+          channel.confirm_select
           exchange = channel.topic(topic, durable: true)
           exchange.publish(
             event.json,
@@ -20,6 +21,7 @@ module Artsy
             content_type: 'application/json',
             app_id: config.app_name
           )
+          raise 'Publishing event failed' unless channel.wait_for_confirms
         end
       end
 

--- a/lib/artsy-eventservice/artsy/event_service/rabbitmq_connection.rb
+++ b/lib/artsy-eventservice/artsy/event_service/rabbitmq_connection.rb
@@ -14,6 +14,7 @@ module Artsy
         conn = create_conn
         conn.start
         yield(conn)
+      ensure
         conn.stop
       end
 


### PR DESCRIPTION
Puts channel in "confirm" mode while publishing, and wait for confirmation from the RabbitMQ broker, raising an error if message is nack'ed by the broker.