### PR TITLE
Publisher confirms config and shared connection between threads

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,17 +2,17 @@ PATH
   remote: .
   specs:
     artsy-eventservice (1.0.3)
-      bunny (~> 2.6.2)
+      bunny (~> 2.7.1)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    amq-protocol (2.0.1)
+    amq-protocol (2.2.0)
     ast (2.3.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    bunny (2.6.2)
-      amq-protocol (>= 2.0.1)
+    bunny (2.7.1)
+      amq-protocol (>= 2.2.0)
     coderay (1.1.1)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
@@ -76,4 +76,4 @@ RUBY VERSION
    ruby 2.3.0p0
 
 BUNDLED WITH
-   1.14.6
+   1.15.4

--- a/artsy-eventservice.gemspec
+++ b/artsy-eventservice.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
   s.homepage = 'http://github.com/artsy/artsy-eventservice'
   s.licenses = ['MIT']
   s.summary = "Ruby Gem for producing events in Artsy's event stream"
-  s.add_dependency 'bunny', '~> 2.6.2'
+  s.add_dependency 'bunny', '~> 2.7.1'
 end

--- a/lib/artsy-eventservice/artsy/event_service/publisher.rb
+++ b/lib/artsy-eventservice/artsy/event_service/publisher.rb
@@ -2,16 +2,13 @@
 module Artsy
   module EventService
     class Publisher
-      include RabbitMQConnection
-
       def self.publish(topic:, event:, routing_key: nil)
         new.post_event(topic: topic, event: event, routing_key: routing_key)
       end
 
       def post_event(topic:, event:, routing_key: nil)
         raise 'Event missing topic or verb.' if event.verb.to_s.empty? || topic.to_s.empty?
-        connect_to_rabbit do |conn|
-          channel = conn.create_channel
+        RabbitMQConnection.get_channel do |channel|
           channel.confirm_select if config.confirms_enabled
           exchange = channel.topic(topic, durable: true)
           exchange.publish(

--- a/lib/artsy-eventservice/artsy/event_service/rabbitmq_connection.rb
+++ b/lib/artsy-eventservice/artsy/event_service/rabbitmq_connection.rb
@@ -14,10 +14,9 @@ module Artsy
         conn
       end
 
-      # Synchronized access to the connection - rebuild if closed
+      # Synchronized access to the connection
       def self.get_connection
         @mutex.synchronize do
-          @connection = nil if @connection && @connection.closed?
           @connection ||= self.build_connection
         end
       end

--- a/lib/artsy-eventservice/artsy/event_service/rabbitmq_connection.rb
+++ b/lib/artsy-eventservice/artsy/event_service/rabbitmq_connection.rb
@@ -3,44 +3,56 @@ require 'bunny'
 
 module Artsy
   module EventService
-    module RabbitMQConnection
-      # get a new RabbitMQ Client
-      def create_conn
-        Bunny.new(rabbitmq_url, **bunny_params)
-      end
+    class RabbitMQConnection
+      @connection = nil
+      @mutex = Mutex.new
 
-      # Connect, do something and close the connection
-      def connect_to_rabbit
-        conn = create_conn
+      # Build a new connection to RabbitMQ
+      def self.build_connection
+        conn = Bunny.new(self.rabbitmq_url, **self.bunny_params)
         conn.start
-        yield(conn)
+        conn
+      end
+
+      # Synchronized access to the connection - rebuild if closed
+      def self.get_connection
+        @mutex.synchronize do
+          @connection = nil if @connection && @connection.closed?
+          @connection ||= self.build_connection
+        end
+      end
+
+      # Get a channel from the connection - synchronized access to create_channel is provided by Bunny
+      def self.get_channel
+        channel = self.get_connection.create_channel
+        yield channel if block_given?
       ensure
-        conn.stop
+        channel.close if channel && channel.open?
       end
 
-      def rabbitmq_url
-        config.rabbitmq_url
+      def self.rabbitmq_url
+        self.config.rabbitmq_url
       end
 
-      def bunny_params
-        config.tls ? tls_params : no_tls_params
+      def self.bunny_params
+        self.config.tls ? self.tls_params : self.no_tls_params
       end
 
-      def tls_params
+      def self.tls_params
         {
-          tls: config.tls,
-          tls_cert: config.tls_cert,
-          tls_key: config.tls_key,
-          tls_ca_certificates: [config.tls_ca_certificate],
-          verify_peer: config.verify_peer
+          tls: self.config.tls,
+          tls_cert: self.config.tls_cert,
+          tls_key: self.config.tls_key,
+          tls_ca_certificates: [self.config.tls_ca_certificate],
+          verify_peer: self.config.verify_peer
         }
       end
 
-      def no_tls_params
+      def self.no_tls_params
         {}
       end
 
-      def config
+      def self.config
         Artsy::EventService.config
       end
     end

--- a/lib/artsy-eventservice/config.rb
+++ b/lib/artsy-eventservice/config.rb
@@ -13,6 +13,7 @@ module Artsy
       attr_accessor :tls_cert
       attr_accessor :tls_key
       attr_accessor :verify_peer
+      attr_accessor :confirms_enabled
 
       def reset
         self.app_name = nil
@@ -23,6 +24,7 @@ module Artsy
         self.tls_cert = nil
         self.tls_key = nil
         self.verify_peer = nil
+        self.confirms_enabled = true
       end
 
       reset

--- a/spec/artsy-eventstream/artsy/publisher_spec.rb
+++ b/spec/artsy-eventstream/artsy/publisher_spec.rb
@@ -33,13 +33,13 @@ describe Artsy::EventService::Publisher do
       conn = double
       channel = double
       exchange = double
-      allow(Bunny).to receive(:new).and_return(conn)
-      expect(conn).to receive(:start).once
-      expect(conn).to receive(:stop).once
+      allow(Artsy::EventService::RabbitMQConnection).to receive(:get_connection).with(no_args).and_return(conn)
       allow(conn).to receive(:create_channel).and_return(channel)
+      allow(channel).to receive(:open?).and_return(true)
       allow(channel).to receive(:topic).with('test', durable: true).and_return(exchange)
       allow(channel).to receive(:confirm_select)
       allow(channel).to receive(:wait_for_confirms).and_return(true)
+      allow(channel).to receive(:close)
 
       expect(exchange).to receive(:publish).with(
         JSON.generate(hello: true),
@@ -54,13 +54,13 @@ describe Artsy::EventService::Publisher do
       conn = double
       channel = double
       exchange = double
-      allow(Bunny).to receive(:new).and_return(conn)
-      expect(conn).to receive(:start).once
-      expect(conn).to receive(:stop).once
+      allow(Artsy::EventService::RabbitMQConnection).to receive(:get_connection).with(no_args).and_return(conn)
       allow(conn).to receive(:create_channel).and_return(channel)
+      allow(channel).to receive(:open?).and_return(true)
       allow(channel).to receive(:topic).with('test', durable: true).and_return(exchange)
       allow(channel).to receive(:confirm_select)
       allow(channel).to receive(:wait_for_confirms).and_return(true)
+      allow(channel).to receive(:close)
 
       expect(exchange).to receive(:publish).with(
         JSON.generate(hello: true),
@@ -75,13 +75,13 @@ describe Artsy::EventService::Publisher do
       conn = double
       channel = double
       exchange = double
-      allow(Bunny).to receive(:new).and_return(conn)
-      expect(conn).to receive(:start).once
-      expect(conn).to receive(:stop).once
+      allow(Artsy::EventService::RabbitMQConnection).to receive(:get_connection).with(no_args).and_return(conn)
       allow(conn).to receive(:create_channel).and_return(channel)
+      allow(channel).to receive(:open?).and_return(true)
       allow(channel).to receive(:topic).with('test', durable: true).and_return(exchange)
       allow(channel).to receive(:confirm_select)
       allow(channel).to receive(:wait_for_confirms).and_return(false)
+      allow(channel).to receive(:close)
 
       expect(exchange).to receive(:publish).with(
         JSON.generate(hello: true),


### PR DESCRIPTION
- Adds `:confirms_enabled` config option (default true)
- Refactor RabbitMQConnection to a class - initialize connection as a class variable and synchronize access to channels created via get_channel method

This will mean that all (Sidekiq / Puma) threads will share one instance of a `Bunny::Session` (connection) and create their own channels, which is the [recommended method](http://rubybunny.info/articles/concurrency.html#synchronized_writes) for using a shared connection.  This will additionally have the effects that we reduce the overhead and latency of opening/closing a connection (opening a new TCP socket / negotiating SSL etc) for every message published, and we will be able to see long-lived connections for publishers in the RabbitMQ Management interface, like we do for consumer connections.

I haven't done threaded Ruby code in a while, so I would like some feedback around the `RabbitMQConnection.get_connection` and `RabbitMQConnection.get_channel` methods.  Since the `RabbitMQConnection@connection` class var is lazily initialized by the `RabbitMQConnection.build_connection` method once `RabbitMQConnection.get_connection` is first called, I thought it best to synchronize access to this shared object.  I initially had `RabbitMQConnection.build_connection` called during class initialization, but thought this sloppy as well as dangerous as the application would fail to boot if not able to establish a connection.

In the case of calling `Bunny::Session.create_channel`, it appears to be [synchronized internally](http://reference.rubybunny.info/Bunny/Session.html#create_channel-instance_method).