### PR TITLE
add endpoint for arbitrary data

### DIFF
--- a/lib/artsy-eventservice/artsy/event_service.rb
+++ b/lib/artsy-eventservice/artsy/event_service.rb
@@ -2,6 +2,23 @@
 # frozen_string_literal: true
 module Artsy
   module EventService
+
+    # Post data without an event, must be serialized.
+    def self.post_data(topic:, data:, routing_key:)
+      RabbitMQConnection.get_channel do |channel|
+        channel.confirm_select if Artsy::EventService.config.confirms_enabled
+        exchange = channel.topic(topic, durable: true)
+        exchange.publish(
+          data,
+          routing_key: routing_key,
+          persistent: true,
+          content_type: 'application/json',
+          app_id: Artsy::EventService.config.app_name
+        )
+        raise 'Publishing data failed' if Artsy::EventService.config.confirms_enabled && !channel.wait_for_confirms
+      end
+    end
+
     def self.post_event(topic:, event:, routing_key: nil)
       return unless event_stream_enabled?
       Publisher.publish(topic: topic, event: event, routing_key: routing_key || event.routing_key)

--- a/lib/artsy-eventservice/artsy/event_service/publisher.rb
+++ b/lib/artsy-eventservice/artsy/event_service/publisher.rb
@@ -2,24 +2,35 @@
 module Artsy
   module EventService
     class Publisher
-      def self.publish(topic:, event:, routing_key: nil)
+      def self.publish_event(topic:, event:, routing_key: nil)
         new.post_event(topic: topic, event: event, routing_key: routing_key)
       end
 
-      def post_event(topic:, event:, routing_key: nil)
-        raise 'Event missing topic or verb.' if event.verb.to_s.empty? || topic.to_s.empty?
+      def self.publish_data(topic:, data:, routing_key: nil)
+        new.post_data(topic: topic, data: data, routing_key: routing_key)
+      end
+
+      def post_data(topic:, data:, routing_key: nil)
         RabbitMQConnection.get_channel do |channel|
           channel.confirm_select if config.confirms_enabled
           exchange = channel.topic(topic, durable: true)
           exchange.publish(
-            event.json,
-            routing_key: routing_key || event.verb,
+            data,
+            routing_key: routing_key,
             persistent: true,
             content_type: 'application/json',
             app_id: config.app_name
           )
-          raise 'Publishing event failed' if config.confirms_enabled && !channel.wait_for_confirms
+          raise 'Publishing data failed' if config.confirms_enabled && !channel.wait_for_confirms
         end
+      end
+
+      def post_event(topic:, event:, routing_key: nil)
+        raise 'Event missing topic or verb.' if event.verb.to_s.empty? || topic.to_s.empty?
+        post_data(
+          topic: topic,
+          data: event.json,
+          routing_key: routing_key || event.verb)
       end
 
       def config

--- a/spec/artsy-eventstream/artsy/event_service_spec.rb
+++ b/spec/artsy-eventstream/artsy/event_service_spec.rb
@@ -22,12 +22,12 @@ describe Artsy::EventService do
     end
     describe '.post_event' do
       it 'calls publish with proper params' do
-        expect(Artsy::EventService::Publisher).to receive(:publish).with(topic: 'test', event: event, routing_key: 'test.passed')
+        expect(Artsy::EventService::Publisher).to receive(:publish_event).with(topic: 'test', event: event, routing_key: 'test.passed')
 
         Artsy::EventService.post_event(topic: 'test', event: event)
       end
       it 'calls publish with proper params with routing key' do
-        expect(Artsy::EventService::Publisher).to receive(:publish).with(topic: 'test', event: event, routing_key: 'good.route')
+        expect(Artsy::EventService::Publisher).to receive(:publish_event).with(topic: 'test', event: event, routing_key: 'good.route')
 
         Artsy::EventService.post_event(topic: 'test', event: event, routing_key: 'good.route')
       end

--- a/spec/artsy-eventstream/artsy/event_service_spec.rb
+++ b/spec/artsy-eventstream/artsy/event_service_spec.rb
@@ -21,7 +21,7 @@ describe Artsy::EventService do
       allow(Artsy::EventService).to receive(:config).and_return(double(event_stream_enabled: true))
     end
     describe '.post_event' do
-      it 'calls publish with proper params' do
+      it 'calls publish_event with proper params' do
         expect(Artsy::EventService::Publisher).to receive(:publish_event).with(topic: 'test', event: event, routing_key: 'test.passed')
 
         Artsy::EventService.post_event(topic: 'test', event: event)
@@ -30,6 +30,13 @@ describe Artsy::EventService do
         expect(Artsy::EventService::Publisher).to receive(:publish_event).with(topic: 'test', event: event, routing_key: 'good.route')
 
         Artsy::EventService.post_event(topic: 'test', event: event, routing_key: 'good.route')
+      end
+    end
+    describe '.post_data' do
+      it 'calls publish_data with proper params' do
+        expect(Artsy::EventService::Publisher).to receive(:publish_data).with(topic: 'test', data: 'foo', routing_key: 'good.route')
+
+        Artsy::EventService.post_data(topic: 'test', data: 'foo', routing_key: 'good.route')
       end
     end
   end

--- a/spec/artsy-eventstream/artsy/publisher_spec.rb
+++ b/spec/artsy-eventstream/artsy/publisher_spec.rb
@@ -19,15 +19,15 @@ describe Artsy::EventService::Publisher do
 
   describe '.publish' do
     it 'fails when topic is empty' do
-      expect { Artsy::EventService::Publisher.publish(topic: nil, event: event) }.to raise_error 'Event missing topic or verb.'
+      expect { Artsy::EventService::Publisher.publish_event(topic: nil, event: event) }.to raise_error 'Event missing topic or verb.'
     end
     it 'fails when event.verb is empty' do
       allow(event).to receive(:verb).and_return('')
-      expect { Artsy::EventService::Publisher.publish(topic: 'test', event: event) }.to raise_error 'Event missing topic or verb.'
+      expect { Artsy::EventService::Publisher.publish_event(topic: 'test', event: event) }.to raise_error 'Event missing topic or verb.'
     end
     it 'fails when event.verb is nil' do
       allow(event).to receive(:verb).and_return(nil)
-      expect { Artsy::EventService::Publisher.publish(topic: 'test', event: event) }.to raise_error 'Event missing topic or verb.'
+      expect { Artsy::EventService::Publisher.publish_event(topic: 'test', event: event) }.to raise_error 'Event missing topic or verb.'
     end
     it 'uses verb as routing key when calling publish on the exchange without passing routing_key' do
       conn = double
@@ -48,7 +48,7 @@ describe Artsy::EventService::Publisher do
         content_type: 'application/json',
         app_id: 'artsy'
       )
-      Artsy::EventService::Publisher.publish(topic: 'test', event: event)
+      Artsy::EventService::Publisher.publish_event(topic: 'test', event: event)
     end
     it 'uses verb as routing key when calling publish on the exchange without passing routing_key' do
       conn = double
@@ -69,7 +69,7 @@ describe Artsy::EventService::Publisher do
         content_type: 'application/json',
         app_id: 'artsy'
       )
-      Artsy::EventService::Publisher.publish(topic: 'test', event: event, routing_key: 'good.route')
+      Artsy::EventService::Publisher.publish_event(topic: 'test', event: event, routing_key: 'good.route')
     end
     it 'raises an error if event publishing is unconfirmed' do
       conn = double
@@ -91,8 +91,8 @@ describe Artsy::EventService::Publisher do
         app_id: 'artsy'
       )
       expect do
-        Artsy::EventService::Publisher.publish(topic: 'test', event: event, routing_key: 'good.route')
-      end.to raise_error 'Publishing event failed'
+        Artsy::EventService::Publisher.publish_event(topic: 'test', event: event, routing_key: 'good.route')
+      end.to raise_error 'Publishing data failed'
     end
   end
 end


### PR DESCRIPTION
There's a need in gravity to post data in a more generic way where creating a subclass for each message type isn't feasible. This adds an endpoint that lets you just specify the topic, routing key and data to send to rabbitmq.