### PR TITLE
Remove 🔓ing Bunny

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,18 @@
 PATH
   remote: .
   specs:
-    artsy-eventservice (1.0.5)
-      bunny (~> 2.7.1)
+    artsy-eventservice (1.0.6)
+      bunny
 
 GEM
   remote: http://rubygems.org/
   specs:
-    amq-protocol (2.2.0)
+    amq-protocol (2.3.0)
     ast (2.3.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    bunny (2.7.1)
-      amq-protocol (>= 2.2.0)
+    bunny (2.9.2)
+      amq-protocol (~> 2.3.0)
     coderay (1.1.1)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)

--- a/artsy-eventservice.gemspec
+++ b/artsy-eventservice.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
   s.homepage = 'http://github.com/artsy/artsy-eventservice'
   s.licenses = ['MIT']
   s.summary = "Ruby Gem for producing events in Artsy's event stream"
-  s.add_dependency 'bunny', '~> 2.7.1'
+  s.add_dependency 'bunny'
 end

--- a/lib/artsy-eventservice/version.rb
+++ b/lib/artsy-eventservice/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Artsy
   module EventService
-    VERSION = '1.0.5'
+    VERSION = '1.0.6'
   end
 end


### PR DESCRIPTION
# Problem
Looks like `bunny` version `2.7.1` locked by this gem and Sneakers `2.7.0` don't work properly together. Latest version of bunny is `2.9.2` going to unlock setting version and use latest.