### PR TITLE
Updates to handle connection closed and custom headers

### DIFF
--- a/lib/artsy-eventservice/artsy/event_service/publisher.rb
+++ b/lib/artsy-eventservice/artsy/event_service/publisher.rb
@@ -2,15 +2,15 @@
 module Artsy
   module EventService
     class Publisher
-      def self.publish_event(topic:, event:, routing_key: nil)
-        new.post_event(topic: topic, event: event, routing_key: routing_key)
+      def self.publish_event(topic:, event:, routing_key: nil, headers: {})
+        new.post_event(topic: topic, event: event, routing_key: routing_key, headers: headers)
       end
 
-      def self.publish_data(topic:, data:, routing_key: nil)
-        new.post_data(topic: topic, data: data, routing_key: routing_key)
+      def self.publish_data(topic:, data:, routing_key: nil, headers: {})
+        new.post_data(topic: topic, data: data, routing_key: routing_key, headers: headers)
       end
 
-      def post_data(topic:, data:, routing_key: nil)
+      def post_data(topic:, data:, routing_key: nil, headers: {})
         RabbitMQConnection.get_channel do |channel|
           channel.confirm_select if config.confirms_enabled
           exchange = channel.topic(topic, durable: true)
@@ -19,18 +19,21 @@ module Artsy
             routing_key: routing_key,
             persistent: true,
             content_type: 'application/json',
+            headers: headers,
             app_id: config.app_name
           )
           raise 'Publishing data failed' if config.confirms_enabled && !channel.wait_for_confirms
         end
       end
 
-      def post_event(topic:, event:, routing_key: nil)
+      def post_event(topic:, event:, routing_key: nil, headers: {})
         raise 'Event missing topic or verb.' if event.verb.to_s.empty? || topic.to_s.empty?
         post_data(
           topic: topic,
           data: event.json,
-          routing_key: routing_key || event.verb)
+          routing_key: routing_key || event.verb,
+          headers: headers
+        )
       end
 
       def config

--- a/lib/artsy-eventservice/artsy/event_service/rabbitmq_connection.rb
+++ b/lib/artsy-eventservice/artsy/event_service/rabbitmq_connection.rb
@@ -18,6 +18,7 @@ module Artsy
       def self.get_connection
         @mutex.synchronize do
           @connection ||= self.build_connection
+          @connection = self.build_connection if @connection.closed?
         end
       end
 

--- a/spec/artsy-eventstream/artsy/publisher_spec.rb
+++ b/spec/artsy-eventstream/artsy/publisher_spec.rb
@@ -22,11 +22,11 @@ describe Artsy::EventService::Publisher do
       expect { Artsy::EventService::Publisher.publish_event(topic: nil, event: event) }.to raise_error 'Event missing topic or verb.'
     end
     it 'fails when event.verb is empty' do
-      allow(event).to receive(:verb).and_return('')
+      expect(event).to receive(:verb).and_return('')
       expect { Artsy::EventService::Publisher.publish_event(topic: 'test', event: event) }.to raise_error 'Event missing topic or verb.'
     end
     it 'fails when event.verb is nil' do
-      allow(event).to receive(:verb).and_return(nil)
+      expect(event).to receive(:verb).and_return(nil)
       expect { Artsy::EventService::Publisher.publish_event(topic: 'test', event: event) }.to raise_error 'Event missing topic or verb.'
     end
     it 'uses verb as routing key when calling publish on the exchange without passing routing_key' do
@@ -34,12 +34,12 @@ describe Artsy::EventService::Publisher do
       channel = double
       exchange = double
       allow(Artsy::EventService::RabbitMQConnection).to receive(:get_connection).with(no_args).and_return(conn)
-      allow(conn).to receive(:create_channel).and_return(channel)
-      allow(channel).to receive(:open?).and_return(true)
-      allow(channel).to receive(:topic).with('test', durable: true).and_return(exchange)
-      allow(channel).to receive(:confirm_select)
-      allow(channel).to receive(:wait_for_confirms).and_return(true)
-      allow(channel).to receive(:close)
+      expect(conn).to receive(:create_channel).and_return(channel)
+      expect(channel).to receive(:open?).and_return(true)
+      expect(channel).to receive(:topic).with('test', durable: true).and_return(exchange)
+      expect(channel).to receive(:confirm_select)
+      expect(channel).to receive(:wait_for_confirms).and_return(true)
+      expect(channel).to receive(:close)
 
       expect(exchange).to receive(:publish).with(
         JSON.generate(hello: true),
@@ -56,12 +56,12 @@ describe Artsy::EventService::Publisher do
       channel = double
       exchange = double
       allow(Artsy::EventService::RabbitMQConnection).to receive(:get_connection).with(no_args).and_return(conn)
-      allow(conn).to receive(:create_channel).and_return(channel)
-      allow(channel).to receive(:open?).and_return(true)
-      allow(channel).to receive(:topic).with('test', durable: true).and_return(exchange)
-      allow(channel).to receive(:confirm_select)
-      allow(channel).to receive(:wait_for_confirms).and_return(true)
-      allow(channel).to receive(:close)
+      expect(conn).to receive(:create_channel).and_return(channel)
+      expect(channel).to receive(:open?).and_return(true)
+      expect(channel).to receive(:topic).with('test', durable: true).and_return(exchange)
+      expect(channel).to receive(:confirm_select)
+      expect(channel).to receive(:wait_for_confirms).and_return(true)
+      expect(channel).to receive(:close)
 
       expect(exchange).to receive(:publish).with(
         JSON.generate(hello: true),
@@ -78,12 +78,12 @@ describe Artsy::EventService::Publisher do
       channel = double
       exchange = double
       allow(Artsy::EventService::RabbitMQConnection).to receive(:get_connection).with(no_args).and_return(conn)
-      allow(conn).to receive(:create_channel).and_return(channel)
-      allow(channel).to receive(:open?).and_return(true)
-      allow(channel).to receive(:topic).with('test', durable: true).and_return(exchange)
-      allow(channel).to receive(:confirm_select)
-      allow(channel).to receive(:wait_for_confirms).and_return(true)
-      allow(channel).to receive(:close)
+      expect(conn).to receive(:create_channel).and_return(channel)
+      expect(channel).to receive(:open?).and_return(true)
+      expect(channel).to receive(:topic).with('test', durable: true).and_return(exchange)
+      expect(channel).to receive(:confirm_select)
+      expect(channel).to receive(:wait_for_confirms).and_return(true)
+      expect(channel).to receive(:close)
 
       expect(exchange).to receive(:publish).with(
         JSON.generate(hello: true),
@@ -99,13 +99,13 @@ describe Artsy::EventService::Publisher do
       conn = double
       channel = double
       exchange = double
-      allow(Artsy::EventService::RabbitMQConnection).to receive(:get_connection).with(no_args).and_return(conn)
-      allow(conn).to receive(:create_channel).and_return(channel)
-      allow(channel).to receive(:open?).and_return(true)
-      allow(channel).to receive(:topic).with('test', durable: true).and_return(exchange)
-      allow(channel).to receive(:confirm_select)
-      allow(channel).to receive(:wait_for_confirms).and_return(false)
-      allow(channel).to receive(:close)
+      expect(Artsy::EventService::RabbitMQConnection).to receive(:get_connection).with(no_args).and_return(conn)
+      expect(conn).to receive(:create_channel).and_return(channel)
+      expect(channel).to receive(:open?).and_return(true)
+      expect(channel).to receive(:topic).with('test', durable: true).and_return(exchange)
+      expect(channel).to receive(:confirm_select)
+      expect(channel).to receive(:wait_for_confirms).and_return(false)
+      expect(channel).to receive(:close)
 
       expect(exchange).to receive(:publish).with(
         JSON.generate(hello: true),


### PR DESCRIPTION
- Reconstruct connection if connection instantiated but closed (i.e. by broker)
- Pass custom headers through to publishing messages - required to publish messages to a [delayed message exchange](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange) and set their delay via the `x-delay` header