### PR TITLE
Fix missing `properties` when calling `to_json` on the event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 0.1.9
+* Add `to_json` to `BaseEvent` and deprecate `json` - [@ashkan18](https://github.com/ashkan18)
 ### 0.1.5 (3/24/17)
 * Add initializer-style configuration block
 ### 0.1.2 (3/23/17)

--- a/lib/artsy-eventservice/artsy/event_service/publisher.rb
+++ b/lib/artsy-eventservice/artsy/event_service/publisher.rb
@@ -30,7 +30,7 @@ module Artsy
         raise 'Event missing topic or verb.' if event.verb.to_s.empty? || topic.to_s.empty?
         post_data(
           topic: topic,
-          data: event.json,
+          data: event.to_json,
           routing_key: routing_key || event.verb,
           headers: headers
         )

--- a/lib/artsy-eventservice/presenters/events/base_event.rb
+++ b/lib/artsy-eventservice/presenters/events/base_event.rb
@@ -3,6 +3,7 @@ require 'json'
 
 module Events
   class BaseEvent
+    extend Gem::Deprecate
     attr_reader :verb, :subject, :object, :properties
 
     def initialize(user: nil, action:, model:)
@@ -41,6 +42,7 @@ module Events
       # Deprecated, switch to to_json
       to_json
     end
+    deprecate :json, :to_json, 2019, 12
 
     def routing_key
       "#{@object.class.to_s.downcase.gsub('::', '-')}.#{@verb}"

--- a/lib/artsy-eventservice/presenters/events/base_event.rb
+++ b/lib/artsy-eventservice/presenters/events/base_event.rb
@@ -4,11 +4,11 @@ require 'json'
 module Events
   class BaseEvent
     attr_reader :verb, :subject, :object, :properties
+
     def initialize(user: nil, action:, model:)
       @subject = user
       @verb = action
       @object = model
-      @properties = nil
     end
 
     def subject
@@ -30,11 +30,16 @@ module Events
       end
     end
 
-    def json
+    def to_json
       JSON.generate(verb: @verb,
                     subject: subject,
                     object: object,
                     properties: properties)
+    end
+
+    def json
+      # Deprecated, switch to to_json
+      to_json
     end
 
     def routing_key

--- a/spec/artsy-eventstream/artsy/publisher_spec.rb
+++ b/spec/artsy-eventstream/artsy/publisher_spec.rb
@@ -13,7 +13,7 @@ describe Artsy::EventService::Publisher do
     end
     allow(event).to receive_messages(
       verb: 'testing',
-      json: JSON.generate(hello: true)
+      to_json: JSON.generate(hello: true)
     )
   end
 

--- a/spec/artsy-eventstream/presenters/events/base_event_spec.rb
+++ b/spec/artsy-eventstream/presenters/events/base_event_spec.rb
@@ -17,7 +17,7 @@ describe Events::BaseEvent do
   end
   describe '#json' do
     it 'returns proper json' do
-      expect(JSON.parse(event.json)).to match(
+      expect(JSON.parse(event.to_json)).to match(
         'verb' => 'test',
         'subject' => {
           'id' => 'user-1',


### PR DESCRIPTION
# Problem
Calling `to_json` on an `Event` does not include `properties`.

# Cause
`to_json` uses the attributes an not the reader methods, in this case we set `@properties = nil` in the initializer and if the overrider doesn't set it when its called it will never get set.

# Possible solution
override `to_json` on the `BaseEvent` to be what `json` method used to be where we specifically define how the `json` should look like. 
We also deprecate `json` method.